### PR TITLE
change qual variable from double to string, output \n in output bimbam

### DIFF
--- a/source/vcf_parser/app.d
+++ b/source/vcf_parser/app.d
@@ -46,7 +46,7 @@ void main(string[] args){
     auto id = ids[0];
     auto reference = to!string(tokens[3]);
     auto alternate = to!string(tokens[4]);
-    auto qual = to!double(tokens[5]);
+    auto qual = to!string(tokens[5]);
     auto filter = to!string(tokens[6]);
     auto info = tokens[7].split(";");
 
@@ -58,6 +58,7 @@ void main(string[] args){
     outfile.write("alternate => ", alternate);
     outfile.write("qual => ", qual);
     outfile.write("filter => ", filter);
+    outfile.write("\n");
 
     double[string] map_info_to_val;
     foreach(item; info){


### PR DESCRIPTION
QUAL not always a double, from VCF specification v4.2:
QUAL - quality: Phred-scaled quality score for the assertion made in ALT. i.e. −10log10 prob(call in ALT is
wrong). If ALT is ‘.’ (no variant) then this is −10log10 prob(variant), and if ALT is not ‘.’ this is −10log10
prob(no variant). If unknown, the missing value should be specified. (Numeric)